### PR TITLE
feat(dag-w3s-link): proxy post requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import {
   composeMiddleware
 } from '@web3-storage/gateway-lib/middleware'
 import { HttpError } from '@web3-storage/gateway-lib/util'
-import { withDenylist, withCdnCache } from './middleware.js'
+import { withDenylist, withCdnCache, withPostProxy } from './middleware.js'
 
 /**
  * @typedef {import('./bindings').Environment} Environment
@@ -25,6 +25,7 @@ export default {
   fetch (request, env, ctx) {
     const middleware = composeMiddleware(
       withErrorHandler,
+      withPostProxy,
       withHttpGet,
       withContext,
       withParsedIpfsUrl,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -75,3 +75,22 @@ export function withCdnCache (handler) {
     return response
   }
 }
+
+/**
+ * Middleware to proxy all POST requests to the UCANTO Server defined in the environment.
+ *
+ * @type {import('@web3-storage/gateway-lib').Middleware<IpfsUrlContext, IpfsUrlContext, Environment>}
+ */
+export function withPostProxy (handler) {
+  return async (request, env, ctx) => {
+    if (request.method === 'POST') {
+      const originRequest = new Request(request)
+      const url = new URL(request.url)
+      const targetUrl = `${env.GATEWAY_URL}${url.pathname}`
+      const response = await fetch(targetUrl, originRequest)
+      return response
+    }
+
+    return handler(request, env, ctx)
+  }
+}


### PR DESCRIPTION
### Context
The Freeway Gateway will be able to handle UCAN invocations after the PR https://github.com/storacha/freeway/pull/133 gets merged. 
So we need to proxy POST requests sent to the `w3s` to the new UCANTO Server.

### Related Issues
- https://github.com/storacha/project-tracking/issues/212
- https://github.com/storacha/project-tracking/issues/160